### PR TITLE
Fix failing poetry lock

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -244,12 +244,17 @@ module.exports = class extends Generator {
       "--skip-existing"
     ]);
 
+    this.log("Generating Poetry lock file in a temporary virtual environment");
     this.spawnCommandSync("poetry", ["lock"], {
       env: {
         ...process.env,
-        PYENV_VERSION: this.answers.pythonVersion // Allow Poetry to find the correct Python version
+        PYENV_VERSION: this.answers.pythonVersion, // Allow Poetry to find the correct Python version
+        POETRY_VIRTUALENVS_IN_PROJECT: 1 // Allow to easily delete the .venv, see below
       }
     });
+    // Delete Poetry environment, because the developer will create its own Pyenv environment when installing the project
+    this.log("Deleting temporary virtual environment");
+    this.spawnCommandSync("rm", ["-rf", ".venv"]);
   }
 
   end() {


### PR DESCRIPTION
I thought that when running `poetry lock` during the project generation, Poetry was automatically detecting the right pyenv environment to use, but it was not the case (I've been confused by the fact that when I've tested it, it was using my poetry cache and skipping the step).

This PR:
- fixes that issue
- avoids leaving a temporary poetry venv after project generation