### PR TITLE
Remove upper bound pins

### DIFF
--- a/generators/app/templates/common/pyproject.toml
+++ b/generators/app/templates/common/pyproject.toml
@@ -7,28 +7,28 @@ authors = ["<%= authorName %> <<%= authorEmail %>>"]
 [tool.poetry.dependencies]
 python = "<%= pythonVersion %>"
 <% if (includeApi) { -%>
-fastapi = {extras = ["all"], version = "^0.95.1"}
-loguru = "^0.7.0"
+fastapi = {extras = ["all"], version = ">=0.95.1"}
+loguru = ">=0.7.0"
 <% } -%>
 <% if (includeDvc) { -%>
-PyYAML = "^6.0"
+PyYAML = ">=6.0"
 <% } -%>
 
 [tool.poetry.group.dev.dependencies]
 <% if (includeDvc) { -%>
-dvc = {extras = ["<%= dvcRemoteType %>"], version = "^3.28.0"}
+dvc = {extras = ["<%= dvcRemoteType %>"], version = ">=3.28.0"}
 <% } -%>
-mypy = "^1.2"
-pre-commit = "^2"
-pytest = "^7"
-pytest-cov = "^3"
-ruff = "^0.1.5"
+mypy = ">=1.2"
+pre-commit = ">=2"
+pytest = ">=7"
+pytest-cov = ">=3"
+ruff = ">=0.1.5"
 <% if (includeStreamlit) { -%>
-streamlit = "^1.28.0"
+streamlit = ">=1.28.0"
 <% } -%>
 <% if (includeDvc) { -%>
-typer = "^0.9.0"
-types-PyYAML = "^6.0"
+typer = ">=0.9.0"
+types-PyYAML = ">=6.0"
 <% } -%>
 
 [build-system]


### PR DESCRIPTION
Inspired by https://iscinumpy.dev/post/bound-version-constraints/

Right now, I think this would cause the following changes, which all seem sensible to me

```
Package operations: 4 installs, 5 updates, 0 removals

  • Installing annotated-types (0.6.0)
  • Installing pydantic-core (2.14.3)
  • Updating pydantic (1.10.13 -> 2.5.1)
  • Downgrading anyio (4.0.0 -> 3.7.1)
  • Installing pydantic-extra-types (2.1.0)
  • Installing pydantic-settings (2.1.0)
  • Updating fastapi (0.95.2 -> 0.104.1)
  • Updating pre-commit (2.21.0 -> 3.5.0)
  • Updating pytest-cov (3.0.0 -> 4.1.0)
```
