### PR TITLE
Fix/docker file building error

### DIFF
--- a/generators/app/templates/api/Dockerfile
+++ b/generators/app/templates/api/Dockerfile
@@ -2,7 +2,7 @@
 FROM python:<%= pythonVersion %>-slim-bookworm as curl-stage
 
 # Install curl ; remove apt cache to reduce image size
-RUN apt-get -y update && apt-get -y install curl  && rm -rf /var/lib/apt/lists/*
+RUN apt-get -y update && apt-get -y install curl gcc && rm -rf /var/lib/apt/lists/*
 
 
 FROM curl-stage as poetry-requirements-stage

--- a/generators/app/templates/api/Dockerfile
+++ b/generators/app/templates/api/Dockerfile
@@ -1,5 +1,5 @@
 # Docker multi-stage building, as recommended by https://fastapi.tiangolo.com/deployment/docker/#docker-image-with-poetry
-FROM python:<%= pythonVersion %>-slim-buster as curl-stage
+FROM python:<%= pythonVersion %>-slim-bookworm as curl-stage
 
 # Install curl ; remove apt cache to reduce image size
 RUN apt-get -y update && apt-get -y install curl  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Update the Dockerfile to :
- Use a more recent image of Debian
Buster seems to not be used by the official python org on Docker Hub : https://github.com/docker-library/python

- Add a missing installation of gcc