### PR TITLE
fix: Inconstancy between make and pre-commit files

### DIFF
--- a/generators/app/templates/common/.pre-commit-config.yaml
+++ b/generators/app/templates/common/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     stages: [commit]
   - id: lint-check
     name: Linting (ruff)
-    entry: ruff check
+    entry: make lint-check
     language: system
     types: [python]
     stages: [commit]


### PR DESCRIPTION
Current pre-commit does a lint-check on all files to commit.
However, the make command for lint-check only checks files in src and tests.