### PR TITLE
feat: add dot-env-plugin for env variables

### DIFF
--- a/generators/app/templates/common/pyproject.toml
+++ b/generators/app/templates/common/pyproject.toml
@@ -22,6 +22,7 @@ mypy = "^1.2"
 pre-commit = "^2"
 pytest = "^7"
 pytest-cov = "^3"
+poetry-dotenv-plugin = "^0.2.0"
 ruff = "^0.1.5"
 <% if (includeStreamlit) { -%>
 streamlit = "^1.28.0"

--- a/generators/app/templates/gitignore/gitignore
+++ b/generators/app/templates/gitignore/gitignore
@@ -17,3 +17,6 @@ __pycache__/
 
 # macOS
 .DS_Store
+
+# env variables
+.env


### PR DESCRIPTION
Add environment variable manager `poetry-dotenv-plugin` to automatically load .env file when running `poetry run .....`

Changes :

- add `poetry-dotenv-plugin` dependency in `pyproject.toml` 
- create `.env` file automatically when we create a new project
- add `.env` file to `.gitignore`

→ Now when we run `poetry run .....` all the variables in `.env` are automatically loaded